### PR TITLE
fix: Large file size error

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,18 +196,21 @@ def success():
 
         otp = generate_otp()
         totalfilesize = 0
+
         for f in request.files.getlist("files"):
             file_name = f.filename
             file_data = f.read()
             totalfilesize += sys.getsizeof(file_data)
+            if totalfilesize >= fortyMb_inbytes:
+                return render_template("share.html", error="Your files exceed the memory limit")
+
+        for f in request.files.getlist("files"):
+            file_name = f.filename
+            file_data = f.read()
             # print(f"{file_name} written to database along with its name {f.filename.split('.')[0]}")
- 
-        if totalfilesize >= fortyMb_inbytes:
-            return render_template("share.html", error="Your files exceed the memory limit")
+            enter_file_to_db(user_name, otp, file_name, to_binary(file_data))
 
-        enter_file_to_db(user_name, otp, file_name, to_binary(file_data))
-
-    return render_template("success.html", details=(otp, user_name))
+        return render_template("success.html", details=(otp, user_name))
 
 
 @app.route("/get/", methods=['GET', 'POST'])

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import random
 from zipfile import ZipFile
 from flask import Flask, render_template, redirect, request, url_for
@@ -198,12 +199,13 @@ def success():
         for f in request.files.getlist("files"):
             file_name = f.filename
             file_data = f.read()
-            totalfilesize += len(file_data)
-            enter_file_to_db(user_name, otp, file_name, to_binary(file_data))
+            totalfilesize += sys.getsizeof(file_data)
             # print(f"{file_name} written to database along with its name {f.filename.split('.')[0]}")
  
         if totalfilesize >= fortyMb_inbytes:
             return render_template("share.html", error="Your files exceed the memory limit")
+
+        enter_file_to_db(user_name, otp, file_name, to_binary(file_data))
 
     return render_template("success.html", details=(otp, user_name))
 


### PR DESCRIPTION
Application crashed when the large files, more than 40MB were
uploaded.

Solution was to calculating the total size of each file using
sys.getsizeof and tabulating the total. If the size was above
40MB an error message is displayed to the viewer.

Also, I moved the database insertion enter_file_to_db() function call below where we check of the total file size to make sure it is below 40MB before saving to the database.