### PR TITLE
feature: Check size before upload

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,0 +1,27 @@
+
+const uploadBttn = document.getElementById('upload-bttn');
+const fileInput = document.getElementById('files');
+
+uploadBttn.disable = true;
+uploadBttn.style.backgroundColor = '#AAAAAA';
+
+
+const checkTotalFileSize = () => {
+    const allFiles = [...fileInput.files];
+    let totalsize = 0;
+    for (let i = 0; i < allFiles.length; i++) {
+        totalsize += allFiles[i].size;
+    }
+    if (totalsize === 0) return;
+    if (totalsize > 41943040) {
+        alert('Total file size exceeds 40MB limit.')
+    } else {
+        uploadBttn.disabled = false;
+        uploadBttn.style.backgroundColor = '#0B5ED7';
+    }
+}
+
+
+if (fileInput) {
+    fileInput.addEventListener('change', checkTotalFileSize);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
     {% block content %} {% endblock %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
   </body>
 
 </html>

--- a/templates/share.html
+++ b/templates/share.html
@@ -26,7 +26,7 @@
       <div id="emailHelp" class="form-text">*Combined size of all files should not exceed 40MB</div>
       <br>
 
-      <input onclick="showuploading()" class="btn btn-primary" type="submit" value="Share Files" style="margin-top:20px;  height:auto ; width :auto;font-size:20px ;padding:10px">
+      <button id="upload-bttn" onclick="showuploading()" class="btn btn-primary" type="submit" style="margin-top:20px;height:auto;width:auto;font-size:20px;padding:10px">Share files</button>
 
     </form> 
 


### PR DESCRIPTION
Files were uploaded and then the size was checked.
Javascript can now check the size of the files before they are
uploaded. If the total size of the files exceeds 40MB an alert is
raised. The "Share files button" is disabled on page load. If
total file size is less than 40MB the button is enabled.